### PR TITLE
fix(tools): prevent ToolRegistry.EMPTY from being a shared mutable singleton

### DIFF
--- a/agents/agents-tools/src/commonMain/kotlin/ai/koog/agents/core/tools/ToolRegistry.kt
+++ b/agents/agents-tools/src/commonMain/kotlin/ai/koog/agents/core/tools/ToolRegistry.kt
@@ -185,9 +185,12 @@ public class ToolRegistry private constructor(tools: List<Tool<*, *>> = emptyLis
         public operator fun invoke(init: Builder.() -> Unit): ToolRegistry = Builder().apply(init).build()
 
         /**
-         * A constant representing an empty registry with no tools.
-         * TODO(KG-676): ToolRegistry is mutable but stored as an immutable object.
+         * Returns a new empty registry with no tools.
+         *
+         * A new instance is returned on each access to prevent shared mutable state:
+         * since [ToolRegistry] is mutable (via [add]/[addAll]), a singleton would allow callers
+         * to inadvertently corrupt the shared object, affecting all other users of [EMPTY].
          */
-        public val EMPTY: ToolRegistry = ToolRegistry(emptyList())
+        public val EMPTY: ToolRegistry get() = ToolRegistry(emptyList())
     }
 }

--- a/agents/agents-tools/src/commonTest/kotlin/ai/koog/agents/core/tools/serialization/ToolRegistryTest.kt
+++ b/agents/agents-tools/src/commonTest/kotlin/ai/koog/agents/core/tools/serialization/ToolRegistryTest.kt
@@ -107,6 +107,24 @@ class ToolRegistryTest {
         assertTrue(combinedRegistry.tools.contains(tool2))
     }
 
+    /**
+     * Regression test for KG-676: ToolRegistry.EMPTY must not be a shared mutable singleton.
+     * Adding a tool to one reference of EMPTY must not affect subsequent accesses to EMPTY.
+     */
+    @Test
+    fun testEmptyRegistryIsolatedFromMutation() {
+        val emptyBefore = ToolRegistry.EMPTY
+        assertTrue(emptyBefore.tools.isEmpty())
+
+        // Mutate a reference obtained from EMPTY
+        emptyBefore.add(tool1)
+        assertEquals(1, emptyBefore.tools.size)
+
+        // A fresh access to EMPTY must still return an empty registry
+        val emptyAfter = ToolRegistry.EMPTY
+        assertTrue(emptyAfter.tools.isEmpty(), "ToolRegistry.EMPTY was polluted by mutation of a previous reference")
+    }
+
     @Test
     fun testGetToolByArgs() = runTest {
         val tool = sampleRegistry.getTool(tool1.name) as SampleTool


### PR DESCRIPTION
## Summary

Fixes [KG-676](https://youtrack.jetbrains.com/issue/KG-676): `ToolRegistry.EMPTY` was declared as a `val` holding a single shared instance, but `ToolRegistry` is mutable (exposes `add`/`addAll` methods). Any caller that mutated that shared instance would silently corrupt `EMPTY` for all other users.

**Root cause:** `public val EMPTY: ToolRegistry = ToolRegistry(emptyList())` — singleton, not immutable.

**Fix:** Convert to a computed property with a custom getter so each access returns a fresh instance:
```kotlin
public val EMPTY: ToolRegistry get() = ToolRegistry(emptyList())
```

## Changes

- `ToolRegistry.kt`: Changed `EMPTY` from a stored singleton to a computed property that returns a new empty instance on each access.
- `ToolRegistryTest.kt`: Added `testEmptyRegistryIsolatedFromMutation` regression test that mutates a reference obtained from `EMPTY` and then verifies a subsequent access to `EMPTY` is still empty.

## Test plan

- [ ] `testEmptyRegistryIsolatedFromMutation` passes: mutating one `EMPTY` reference does not affect the next access
- [ ] `testCombineWithEmptyRegistry` continues to pass
- [ ] All existing `ToolRegistryTest` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)