### PR TITLE
Fix DeepSeek Reasoner reasoning_content with tool_calls

### DIFF
--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/base/models/OpenAIDataModels.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/base/models/OpenAIDataModels.kt
@@ -129,6 +129,7 @@ public sealed interface OpenAIMessage {
     @SerialName("assistant")
     public class Assistant(
         override val content: Content? = null,
+        @SerialName("reasoning_content")
         public val reasoningContent: String? = null,
         public val audio: OpenAIAudio? = null,
         public val name: String? = null,


### PR DESCRIPTION
## Summary

Fixes HTTP 400 error when using DeepSeek Reasoner model with tool calls.

## Problem

DeepSeek Reasoner API returns `reasoning_content` and `tool_calls` together in a single assistant message. The previous implementation created separate `Message.Reasoning` and `Message.Tool.Call` messages, causing the API to reject subsequent requests with:

```
Missing 'reasoning_content' field in the assistant message at message index 3
```

This occurred because:
1. First request: DeepSeek returns `{reasoning_content, tool_calls}` in one message
2. Koog split this into separate `Reasoning` + `Tool.Call` messages  
3. Second request with tool results: Koog sent `{reasoning: null, tool_calls: [...]}` 
4. DeepSeek API requires reasoning_content to be present if it was in the original message

## Solution

When `reasoning_content` and `tool_calls` appear together:
1. Only create `Tool.Call` messages (no separate `Reasoning` message)
2. Embed `reasoning_content` in the first tool call's `metaInfo.additionalInfo`
3. In `convertPromptToMessages()`, extract reasoning from metaInfo and recombine with tool calls into a single `OpenAIMessage.Assistant` message

This ensures the API request format matches DeepSeek's requirements: `reasoning_content` and `tool_calls` must be in the same assistant message.

## Changes

- `AbstractOpenAILLMClient.toMessageResponses()`: New case for combined reasoning + tool calls
- `AbstractOpenAILLMClient.convertPromptToMessages()`: Extract and recombine reasoning from tool call metaInfo

## Testing

Tested with DeepSeek Reasoner (`deepseek-reasoner`) in a Diplomacy game AI agent:
- ✅ Multi-turn conversations work correctly
- ✅ Tool calls execute properly  
- ✅ No "Missing reasoning_content" errors
- ✅ Reasoning content preserved across conversation turns

---
> Replicated from JetBrains/koog#1456 (author: @RhoMancer) for review practice.