### PR TITLE
test: add test coverage for EditFileTool and patch subsystem

### DIFF
--- a/agents/agents-ext/src/commonTest/kotlin/ai/koog/agents/ext/tool/file/patch/FilePatchTest.kt
+++ b/agents/agents-ext/src/commonTest/kotlin/ai/koog/agents/ext/tool/file/patch/FilePatchTest.kt
@@ -1,0 +1,48 @@
+package ai.koog.agents.ext.tool.file.patch
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class FilePatchTest {
+
+    @Test
+    fun `isDelete is true when original is non-empty and replacement is empty`() {
+        val patch = FilePatch(original = "some text", replacement = "")
+        assertTrue(patch.isDelete)
+        assertFalse(patch.isReplace)
+        assertFalse(patch.isRewrite)
+    }
+
+    @Test
+    fun `isReplace is true when both are non-empty and different`() {
+        val patch = FilePatch(original = "old", replacement = "new")
+        assertTrue(patch.isReplace)
+        assertFalse(patch.isDelete)
+        assertFalse(patch.isRewrite)
+    }
+
+    @Test
+    fun `isRewrite is true when original is empty and replacement is non-empty`() {
+        val patch = FilePatch(original = "", replacement = "new content")
+        assertTrue(patch.isRewrite)
+        assertFalse(patch.isDelete)
+        assertFalse(patch.isReplace)
+    }
+
+    @Test
+    fun `isReplace is false when original and replacement are identical`() {
+        val patch = FilePatch(original = "same", replacement = "same")
+        assertFalse(patch.isReplace)
+        assertFalse(patch.isDelete)
+        assertFalse(patch.isRewrite)
+    }
+
+    @Test
+    fun `all flags are false when both original and replacement are empty`() {
+        val patch = FilePatch(original = "", replacement = "")
+        assertFalse(patch.isDelete)
+        assertFalse(patch.isReplace)
+        assertFalse(patch.isRewrite)
+    }
+}

--- a/agents/agents-ext/src/commonTest/kotlin/ai/koog/agents/ext/tool/file/patch/TokenNormalizedPatchApplierTest.kt
+++ b/agents/agents-ext/src/commonTest/kotlin/ai/koog/agents/ext/tool/file/patch/TokenNormalizedPatchApplierTest.kt
@@ -1,0 +1,252 @@
+package ai.koog.agents.ext.tool.file.patch
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class TokenNormalizedPatchApplierTest {
+
+    // --- tokenize tests ---
+
+    @Test
+    fun `tokenize splits on whitespace`() {
+        val tokens = tokenize("hello world")
+        val contents = tokens.map { it.content }
+        assertEquals(listOf("hello", " ", "world"), contents)
+    }
+
+    @Test
+    fun `tokenize splits on newlines`() {
+        val tokens = tokenize("line1\nline2")
+        val contents = tokens.map { it.content }
+        assertEquals(listOf("line1", "\n", "line2"), contents)
+    }
+
+    @Test
+    fun `tokenize splits on punctuation`() {
+        val tokens = tokenize("a(b)")
+        val contents = tokens.map { it.content }
+        assertEquals(listOf("a", "(", "b", ")"), contents)
+    }
+
+    @Test
+    fun `tokenize handles empty string`() {
+        val tokens = tokenize("")
+        assertTrue(tokens.isEmpty())
+    }
+
+    @Test
+    fun `tokenize preserves ranges correctly`() {
+        val text = "ab cd"
+        val tokens = tokenize(text)
+        tokens.forEach { token ->
+            assertEquals(token.content, text.substring(token.range))
+        }
+    }
+
+    @Test
+    fun `tokenize splits on multiple separator types`() {
+        val tokens = tokenize("func(a, b)")
+        val contents = tokens.map { it.content }
+        assertEquals(listOf("func", "(", "a", ",", " ", "b", ")"), contents)
+    }
+
+    @Test
+    fun `tokenize identifies whitespace tokens`() {
+        val tokens = tokenize("a b")
+        val spaceToken = tokens.find { it.content == " " }
+        assertNotNull(spaceToken)
+        assertTrue(spaceToken.isWhitespace)
+    }
+
+    @Test
+    fun `tokenize identifies non-whitespace tokens`() {
+        val tokens = tokenize("hello")
+        assertEquals(1, tokens.size)
+        assertFalse(tokens[0].isWhitespace)
+    }
+
+    // --- TokenList.find tests ---
+
+    @Test
+    fun `find locates matching subsequence`() {
+        val content = TokenList(tokenize("hello world foo"))
+        val search = TokenList(tokenize("world"))
+        val range = content.find(search)
+        assertNotNull(range)
+    }
+
+    @Test
+    fun `find returns null when no match`() {
+        val content = TokenList(tokenize("hello world"))
+        val search = TokenList(tokenize("missing"))
+        val range = content.find(search)
+        assertNull(range)
+    }
+
+    @Test
+    fun `find uses custom equality function`() {
+        val content = TokenList(tokenize("Hello World"))
+        val search = TokenList(tokenize("hello world"))
+        val range = content.find(search) { fst, snd ->
+            fst.content.equals(snd.content, ignoreCase = true)
+        }
+        assertNotNull(range)
+    }
+
+    @Test
+    fun `find returns first occurrence`() {
+        val content = TokenList(tokenize("aaa bbb aaa"))
+        val search = TokenList(tokenize("aaa"))
+        val range = content.find(search)
+        assertNotNull(range)
+        assertEquals(0, range.first)
+    }
+
+    // --- TokenList.replace tests ---
+
+    @Test
+    fun `replace substitutes tokens in range`() {
+        val content = TokenList(tokenize("hello world"))
+        val replacement = TokenList(tokenize("earth"))
+        val search = content.find(TokenList(tokenize("world")))!!
+        val result = content.replace(search, replacement)
+        assertEquals("hello earth", result.text)
+    }
+
+    @Test
+    fun `replace at start of token list`() {
+        val content = TokenList(tokenize("old stuff"))
+        val replacement = TokenList(tokenize("new"))
+        val search = content.find(TokenList(tokenize("old")))!!
+        val result = content.replace(search, replacement)
+        assertEquals("new stuff", result.text)
+    }
+
+    @Test
+    fun `replace at end of token list`() {
+        val content = TokenList(tokenize("keep this"))
+        val replacement = TokenList(tokenize("that"))
+        val search = content.find(TokenList(tokenize("this")))!!
+        val result = content.replace(search, replacement)
+        assertEquals("keep that", result.text)
+    }
+
+    // --- applyTokenNormalizedPatch tests ---
+
+    @Test
+    fun `patch replaces matching text`() {
+        val result = applyTokenNormalizedPatch(
+            "hello world",
+            FilePatch("hello", "goodbye")
+        )
+        assertIs<PatchApplyResult.Success>(result)
+        assertEquals("goodbye world", result.updatedContent)
+    }
+
+    @Test
+    fun `patch returns OriginalNotFound when no match`() {
+        val result = applyTokenNormalizedPatch(
+            "hello world",
+            FilePatch("missing", "replacement")
+        )
+        assertIs<PatchApplyResult.Failure.OriginalNotFound>(result)
+    }
+
+    @Test
+    fun `patch rewrites content when original is empty`() {
+        val result = applyTokenNormalizedPatch(
+            "old content",
+            FilePatch("", "new content")
+        )
+        assertIs<PatchApplyResult.Success>(result)
+        assertEquals("new content", result.updatedContent)
+    }
+
+    @Test
+    fun `patch deletes matching text when replacement is empty`() {
+        val result = applyTokenNormalizedPatch(
+            "keep remove keep",
+            FilePatch("remove ", "")
+        )
+        assertIs<PatchApplyResult.Success>(result)
+        assertEquals("keep keep", result.updatedContent)
+    }
+
+    @Test
+    fun `patch matches case-insensitively`() {
+        val result = applyTokenNormalizedPatch(
+            "Hello World",
+            FilePatch("hello world", "Goodbye World")
+        )
+        assertIs<PatchApplyResult.Success>(result)
+        assertEquals("Goodbye World", result.updatedContent)
+    }
+
+    @Test
+    fun `patch matches with different whitespace`() {
+        val result = applyTokenNormalizedPatch(
+            "hello   world",
+            FilePatch("hello world", "hello earth")
+        )
+        assertIs<PatchApplyResult.Success>(result)
+        assertEquals("hello earth", result.updatedContent)
+    }
+
+    @Test
+    fun `patch handles multiline replacement`() {
+        val content = "line1\nline2\nline3"
+        val result = applyTokenNormalizedPatch(
+            content,
+            FilePatch("line2", "replaced")
+        )
+        assertIs<PatchApplyResult.Success>(result)
+        assertEquals("line1\nreplaced\nline3", result.updatedContent)
+    }
+
+    @Test
+    fun `patch preserves content when both original and replacement are empty`() {
+        val result = applyTokenNormalizedPatch(
+            "content",
+            FilePatch("", "")
+        )
+        assertIs<PatchApplyResult.Success>(result)
+        assertEquals("content", result.updatedContent)
+    }
+
+    @Test
+    fun `PatchApplyResult isSuccess returns true for Success`() {
+        val result: PatchApplyResult = PatchApplyResult.Success("content")
+        assertTrue(result.isSuccess())
+    }
+
+    @Test
+    fun `PatchApplyResult isSuccess returns false for Failure`() {
+        val result: PatchApplyResult = PatchApplyResult.Failure.OriginalNotFound
+        assertFalse(result.isSuccess())
+    }
+
+    @Test
+    fun `patch matches with tab vs space differences`() {
+        val result = applyTokenNormalizedPatch(
+            "hello\tworld",
+            FilePatch("hello world", "hello earth")
+        )
+        assertIs<PatchApplyResult.Success>(result)
+        assertEquals("hello earth", result.updatedContent)
+    }
+
+    @Test
+    fun `patch replaces only first occurrence`() {
+        val result = applyTokenNormalizedPatch(
+            "aaa bbb aaa",
+            FilePatch("aaa", "ccc")
+        )
+        assertIs<PatchApplyResult.Success>(result)
+        assertEquals("ccc bbb aaa", result.updatedContent)
+    }
+}

--- a/agents/agents-ext/src/jvmTest/kotlin/ai/koog/agents/ext/tool/file/EditFileToolJvmTest.kt
+++ b/agents/agents-ext/src/jvmTest/kotlin/ai/koog/agents/ext/tool/file/EditFileToolJvmTest.kt
@@ -1,0 +1,219 @@
+package ai.koog.agents.ext.tool.file
+
+import ai.koog.agents.core.tools.DirectToolCallsEnabler
+import ai.koog.agents.core.tools.ToolException
+import ai.koog.agents.core.tools.annotations.InternalAgentToolsApi
+import ai.koog.rag.base.files.JVMFileSystemProvider
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import kotlin.io.path.createDirectories
+import kotlin.io.path.createFile
+import kotlin.io.path.exists
+import kotlin.io.path.readText
+import kotlin.io.path.writeBytes
+import kotlin.io.path.writeText
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@OptIn(InternalAgentToolsApi::class)
+class EditFileToolJvmTest {
+
+    private val fs = JVMFileSystemProvider.ReadWrite
+    private val enabler = object : DirectToolCallsEnabler {}
+    private val tool = EditFileTool(fs)
+
+    @TempDir
+    lateinit var tempDir: Path
+
+    private fun createTestFile(name: String, content: String): Path =
+        tempDir.resolve(name).also {
+            it.parent.createDirectories()
+            it.createFile()
+            it.writeText(content)
+        }
+
+    private suspend fun edit(path: Path, original: String, replacement: String): EditFileTool.Result =
+        tool.execute(EditFileTool.Args(path.toString(), original, replacement), enabler)
+
+    @Test
+    fun `descriptor is configured correctly`() {
+        val descriptor = tool.descriptor
+        assertEquals("edit_file", descriptor.name)
+        assertTrue(descriptor.description.isNotEmpty())
+        assertEquals(
+            listOf("path", "original", "replacement"),
+            descriptor.requiredParameters.map { it.name }
+        )
+        assertTrue(descriptor.optionalParameters.isEmpty())
+    }
+
+    @Test
+    fun `Args are passed correctly`() {
+        val args = EditFileTool.Args("/tmp/test.txt", "old", "new")
+        assertEquals("/tmp/test.txt", args.path)
+        assertEquals("old", args.original)
+        assertEquals("new", args.replacement)
+    }
+
+    @Test
+    fun `replaces text in existing file`() = runBlocking {
+        val f = createTestFile("hello.txt", "hello world")
+
+        val result = edit(f, "hello", "goodbye")
+
+        assertTrue(result.applied)
+        assertEquals("goodbye world", f.readText())
+    }
+
+    @Test
+    fun `creates new file when original is empty (rewrite mode)`() = runBlocking {
+        val f = tempDir.resolve("new_file.txt")
+
+        val result = edit(f, "", "brand new content")
+
+        assertTrue(result.applied)
+        assertTrue(f.exists())
+        assertEquals("brand new content", f.readText())
+    }
+
+    @Test
+    fun `creates parent directories for new file`() = runBlocking {
+        val f = tempDir.resolve("nested/deep/dir/file.txt")
+
+        val result = edit(f, "", "content in nested file")
+
+        assertTrue(result.applied)
+        assertTrue(f.exists())
+        assertEquals("content in nested file", f.readText())
+    }
+
+    @Test
+    fun `deletes text when replacement is empty`() = runBlocking {
+        val f = createTestFile("delete.txt", "keep this remove this keep that")
+
+        val result = edit(f, "remove this ", "")
+
+        assertTrue(result.applied)
+        assertEquals("keep this keep that", f.readText())
+    }
+
+    @Test
+    fun `rewrites entire file when original is empty on existing file`() = runBlocking {
+        val f = createTestFile("rewrite.txt", "old content")
+
+        val result = edit(f, "", "completely new content")
+
+        assertTrue(result.applied)
+        assertEquals("completely new content", f.readText())
+    }
+
+    @Test
+    fun `returns failure when original text is not found`() = runBlocking {
+        val f = createTestFile("notfound.txt", "actual content here")
+
+        val result = edit(f, "nonexistent text", "replacement")
+
+        assertFalse(result.applied)
+        assertEquals("actual content here", f.readText())
+    }
+
+    @Test
+    fun `throws ValidationFailure for non-text file`() {
+        val bin = tempDir.resolve("binary.dat").also {
+            it.parent.createDirectories()
+            it.createFile()
+            it.writeBytes(byteArrayOf(0x00, 0xFF.toByte(), 0x00, 0xFF.toByte()))
+        }
+        assertThrows<ToolException.ValidationFailure> {
+            runBlocking { edit(bin, "something", "else") }
+        }
+    }
+
+    @Test
+    fun `matches original text case-insensitively`() = runBlocking {
+        val f = createTestFile("case.txt", "Hello World")
+
+        val result = edit(f, "hello world", "Goodbye World")
+
+        assertTrue(result.applied)
+        assertEquals("Goodbye World", f.readText())
+    }
+
+    @Test
+    fun `matches original text with different whitespace`() = runBlocking {
+        val f = createTestFile("whitespace.txt", "hello   world")
+
+        val result = edit(f, "hello world", "hello earth")
+
+        assertTrue(result.applied)
+        assertEquals("hello earth", f.readText())
+    }
+
+    @Test
+    fun `replaces multiline content`() = runBlocking {
+        val content = "line1\nline2\nline3\nline4"
+        val f = createTestFile("multi.txt", content)
+
+        val result = edit(f, "line2\nline3", "replaced2\nreplaced3")
+
+        assertTrue(result.applied)
+        assertEquals("line1\nreplaced2\nreplaced3\nline4", f.readText())
+    }
+
+    @Test
+    fun `preserves surrounding content during replacement`() = runBlocking {
+        val content = "prefix==>target<==suffix"
+        val f = createTestFile("surround.txt", content)
+
+        val result = edit(f, "target", "REPLACED")
+
+        assertTrue(result.applied)
+        assertEquals("prefix==>REPLACED<==suffix", f.readText())
+    }
+
+    @Test
+    fun `Result textForLLM shows success message`() = runBlocking {
+        val f = createTestFile("success.txt", "old text")
+
+        val result = edit(f, "old text", "new text")
+
+        assertTrue(result.textForLLM().contains("Successfully"))
+        assertTrue(result.textForLLM().contains("edited file"))
+    }
+
+    @Test
+    fun `Result textForLLM shows failure message when original not found`() = runBlocking {
+        val f = createTestFile("fail.txt", "actual content")
+
+        val result = edit(f, "missing content", "replacement")
+
+        assertTrue(result.textForLLM().contains("not"))
+        assertTrue(result.textForLLM().contains("modified"))
+    }
+
+    @Test
+    fun `no-op when both original and replacement are empty`() = runBlocking {
+        val f = createTestFile("noop.txt", "content stays")
+
+        val result = edit(f, "", "")
+
+        // Empty original + empty replacement: patch is neither delete, replace, rewrite
+        // so the content stays unchanged, but it returns Success with original content
+        assertTrue(result.applied)
+        assertEquals("content stays", f.readText())
+    }
+
+    @Test
+    fun `replaces only the first occurrence`() = runBlocking {
+        val f = createTestFile("first.txt", "aaa bbb aaa")
+
+        val result = edit(f, "aaa", "ccc")
+
+        assertTrue(result.applied)
+        assertEquals("ccc bbb aaa", f.readText())
+    }
+}


### PR DESCRIPTION
## Summary

Adds comprehensive test coverage for `EditFileTool` and its underlying patch subsystem (`FilePatch`, `TokenNormalizedPatchApplier`), which previously had **zero test coverage**.

## Test Files Added

### `EditFileToolJvmTest.kt` (16 tests)
JVM integration tests for the `EditFileTool`, following the same patterns as existing sibling tests (`WriteFileToolJvmTest`, `ReadFileToolJvmTest`).

Covers:
- **Descriptor validation** — tool name, description, required/optional parameters
- **Args data class** — field mapping
- **Text replacement** — basic replace in existing file
- **Rewrite mode** — creating new files with empty original
- **Parent directory creation** — nested path handling for new files
- **Text deletion** — empty replacement removes matched content
- **File rewrite** — empty original on existing file replaces all content
- **Failure case** — original text not found returns failure, file unchanged
- **Binary file validation** — throws `ValidationFailure` for non-text files
- **Case-insensitive matching** — fuzzy case matching via token normalization
- **Whitespace-insensitive matching** — fuzzy whitespace matching
- **Multiline replacement** — cross-line edit operations
- **Content preservation** — surrounding content unaffected by patch
- **Result rendering** — `textForLLM()` output for success and failure
- **No-op edge case** — both original and replacement empty
- **First-occurrence-only** — replaces only the first match

### `FilePatchTest.kt` (5 tests)
Common (multiplatform) unit tests for the `FilePatch` data class.

Covers:
- `isDelete` — non-empty original + empty replacement
- `isReplace` — both non-empty and different
- `isRewrite` — empty original + non-empty replacement
- Identical original/replacement — no flags set
- Both empty — no flags set

### `TokenNormalizedPatchApplierTest.kt` (20 tests)
Common (multiplatform) unit tests for the tokenizer, `TokenList`, and `applyTokenNormalizedPatch`.

Covers:
- **Tokenizer** — whitespace splitting, newline splitting, punctuation splitting, empty input, range correctness, multi-separator types, whitespace/non-whitespace token identification
- **TokenList.find** — matching subsequence, no match, custom equality, first-occurrence semantics
- **TokenList.replace** — mid-list, start, and end replacements
- **applyTokenNormalizedPatch** — replace, delete, rewrite, no-op, case-insensitive, whitespace-insensitive, tab-vs-space, multiline, first-occurrence-only, `OriginalNotFound` failure
- **PatchApplyResult.isSuccess** — success and failure variants

## Motivation

`EditFileTool.kt` and its patch dependencies (`FilePatch`, `TokenNormalizedPatchApplier`) had no automated tests. All sibling file tools (`ReadFileTool`, `WriteFileTool`, `ListDirectoryTool`) already have thorough test suites. This PR closes that gap.