### PR TITLE
fix(prompt): ensure `reasoningContent` present with tool calls in DeepSeek

### DIFF
--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-dashscope-client/src/jvmTest/kotlin/dashscope/DashscopeLLMClientTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-dashscope-client/src/jvmTest/kotlin/dashscope/DashscopeLLMClientTest.kt
@@ -128,6 +128,38 @@ class DashscopeLLMClientTest {
         }
     """.trimIndent()
 
+    //language=json
+    val toolCallWithReasoningBody = """
+        {
+          "id": "chatcmpl-tool",
+          "object": "chat.completion",
+          "created": 1716920005,
+          "model": "qwen-plus",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "content": "",
+                "reasoning_content": "I should call the weather tool first.",
+                "tool_calls": [
+                  {
+                    "id": "call_weather",
+                    "type": "function",
+                    "function": {
+                      "name": "weather",
+                      "arguments": "{\"city\":\"Boston\"}"
+                    }
+                  }
+                ]
+              },
+              "finish_reason": "tool_calls"
+            }
+          ],
+          "usage": {"total_tokens": 10, "prompt_tokens": 5, "completion_tokens": 5}
+        }
+    """.trimIndent()
+
     @Test
     fun testExecute() = runTest {
         var capturedUrl = ""
@@ -237,6 +269,33 @@ class DashscopeLLMClientTest {
         // For now, we'd only verify that streaming flow can be created
         // as MockEngine does not support Ktor SSE end-to-end streaming reliably in tests
         assertNotNull(flow, "Flow should not be null")
+    }
+
+    @Test
+    fun testExecuteToolCallResponsePreservesReasoningMessage() = runTest {
+        val engine = MockEngine { _ ->
+            respond(
+                content = toolCallWithReasoningBody,
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, Json.toString())
+            )
+        }
+        val http = HttpClient(engine) {}
+        val client = DashscopeLLMClient(apiKey = key, baseClient = http, clock = FixedClock)
+
+        val prompt = Prompt.build(id = "p-tool-response", clock = FixedClock) {
+            user("What is the weather in Boston?")
+        }
+
+        val responses = client.execute(prompt, DashscopeModels.QWEN_PLUS)
+
+        assertEquals(2, responses.size, "Response should contain reasoning and tool call")
+        assertIs<Message.Reasoning>(responses[0])
+        assertEquals("I should call the weather tool first.", responses[0].content)
+        val toolCall = assertIs<Message.Tool.Call>(responses[1])
+        assertEquals("call_weather", toolCall.id)
+        assertEquals("weather", toolCall.tool)
+        assertEquals("{\"city\":\"Boston\"}", toolCall.content)
     }
 
     @Test

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-deepseek-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/deepseek/DeepSeekLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-deepseek-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/deepseek/DeepSeekLLMClient.kt
@@ -94,13 +94,7 @@ public class DeepSeekLLMClient @JvmOverloads constructor(
         val deepSeekParams = params.toDeepSeekParams()
         val responseFormat = createResponseFormat(params.schema, model)
 
-        val preparedMessages = if (params.schema != null) {
-            // Add a message having the word `JSON` explicitly
-            // it is required by the deepseek api for structured output
-            messages + OpenAIMessage.Assistant(Content.Text("Respond with JSON"))
-        } else {
-            messages
-        }
+        val preparedMessages = prepareMessagesForDeepSeek(messages, addJsonResponseHint = params.schema != null)
 
         val request = DeepSeekChatCompletionRequest(
             messages = preparedMessages,
@@ -121,6 +115,44 @@ public class DeepSeekLLMClient @JvmOverloads constructor(
         )
 
         return json.encodeToString(DeepSeekChatCompletionRequestSerializer, request)
+    }
+
+    private fun prepareMessagesForDeepSeek(
+        messages: List<OpenAIMessage>,
+        addJsonResponseHint: Boolean = false
+    ): List<OpenAIMessage> {
+        val preparedMessages = mutableListOf<OpenAIMessage>()
+
+        for (message in messages) {
+            val previousMessage = preparedMessages.lastOrNull() as? OpenAIMessage.Assistant
+
+            if (
+                previousMessage?.reasoningContent != null &&
+                message is OpenAIMessage.Assistant &&
+                message.reasoningContent == null &&
+                !message.toolCalls.isNullOrEmpty()
+            ) {
+                preparedMessages.removeLast()
+                preparedMessages += OpenAIMessage.Assistant(
+                    content = previousMessage.content ?: message.content,
+                    reasoningContent = previousMessage.reasoningContent,
+                    audio = message.audio ?: previousMessage.audio,
+                    name = message.name ?: previousMessage.name,
+                    refusal = message.refusal ?: previousMessage.refusal,
+                    toolCalls = message.toolCalls,
+                    annotations = message.annotations ?: previousMessage.annotations
+                )
+            } else {
+                preparedMessages += message
+            }
+        }
+
+        if (addJsonResponseHint) {
+            // DeepSeek requires an explicit JSON mention for structured output mode.
+            preparedMessages += OpenAIMessage.Assistant(Content.Text("Respond with JSON"))
+        }
+
+        return preparedMessages
     }
 
     override fun processProviderChatResponse(response: DeepSeekChatCompletionResponse): List<LLMChoice> {

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-deepseek-client/src/jvmTest/kotlin/deepseek/DeepSeekLLMClientTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-deepseek-client/src/jvmTest/kotlin/deepseek/DeepSeekLLMClientTest.kt
@@ -6,6 +6,8 @@ import ai.koog.prompt.executor.clients.deepseek.DeepSeekClientSettings
 import ai.koog.prompt.executor.clients.deepseek.DeepSeekLLMClient
 import ai.koog.prompt.executor.clients.deepseek.DeepSeekModels
 import ai.koog.prompt.message.Message
+import ai.koog.prompt.message.RequestMetaInfo
+import ai.koog.prompt.message.ResponseMetaInfo
 import ai.koog.prompt.params.LLMParams
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
@@ -18,6 +20,10 @@ import io.ktor.http.content.TextContent
 import io.ktor.http.headersOf
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -26,6 +32,7 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import kotlin.time.Clock
 import kotlin.time.Instant
+import kotlinx.serialization.json.Json as KotlinxJson
 
 class DeepSeekLLMClientTest {
 
@@ -123,6 +130,39 @@ class DeepSeekLLMClientTest {
               "prompt_cache_hit_tokens" : 0,
               "prompt_cache_miss_tokens" : 35
           }
+        }
+    """.trimIndent()
+
+    //language=json
+    val toolCallWithReasoningBody = """
+        {
+          "id": "chatcmpl-tool",
+          "object": "chat.completion",
+          "created": 1716920005,
+          "system_fingerprint": "dummy",
+          "model": "deepseek-reasoner",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "content": "",
+                "reasoning_content": "I should call the weather tool first.",
+                "tool_calls": [
+                  {
+                    "id": "call_weather",
+                    "type": "function",
+                    "function": {
+                      "name": "weather",
+                      "arguments": "{\"city\":\"Boston\"}"
+                    }
+                  }
+                ]
+              },
+              "finish_reason": "tool_calls"
+            }
+          ],
+          "usage": {"total_tokens": 10, "prompt_tokens": 5, "completion_tokens": 5}
         }
     """.trimIndent()
 
@@ -229,6 +269,94 @@ class DeepSeekLLMClientTest {
         // For now, we'd only verify that streaming flow can be created
         // as MockEngine does not support Ktor SSE end-to-end streaming reliably in tests
         assertNotNull(flow, "Flow should not be null")
+    }
+
+    @Test
+    fun testExecuteToolCallResponsePreservesReasoningMessage() = runTest {
+        val engine = MockEngine { _ ->
+            respond(
+                content = toolCallWithReasoningBody,
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, Json.toString())
+            )
+        }
+        val http = HttpClient(engine) {}
+        val client = DeepSeekLLMClient(apiKey = key, baseClient = http, clock = FixedClock)
+
+        val prompt = Prompt.build(id = "p-tool-response", clock = FixedClock) {
+            user("What is the weather in Boston?")
+        }
+
+        val responses = client.execute(prompt, DeepSeekModels.DeepSeekReasoner)
+
+        assertEquals(2, responses.size, "Response should contain reasoning and tool call")
+        assertIs<Message.Reasoning>(responses[0])
+        assertEquals("I should call the weather tool first.", responses[0].content)
+        val toolCall = assertIs<Message.Tool.Call>(responses[1])
+        assertEquals("call_weather", toolCall.id)
+        assertEquals("weather", toolCall.tool)
+        assertEquals("{\"city\":\"Boston\"}", toolCall.content)
+    }
+
+    @Test
+    fun testExecuteDeepSeekReasonerReplaysReasoningWithToolCalls() = runTest {
+        var capturedBody: String? = null
+        val engine = MockEngine { req ->
+            capturedBody = (req.body as TextContent).text
+            respond(
+                content = body,
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, Json.toString())
+            )
+        }
+        val http = HttpClient(engine) {}
+        val client = DeepSeekLLMClient(apiKey = key, baseClient = http, clock = FixedClock)
+
+        val prompt = Prompt(
+            messages = listOf(
+                Message.User("What's the weather in Boston?", RequestMetaInfo.Empty),
+                Message.Reasoning(
+                    content = "I should call the weather tool first.",
+                    metaInfo = ResponseMetaInfo.Empty
+                ),
+                Message.Tool.Call(
+                    id = "call_weather",
+                    tool = "weather",
+                    content = "{\"city\":\"Boston\"}",
+                    metaInfo = ResponseMetaInfo.Empty
+                ),
+                Message.Tool.Result(
+                    id = "call_weather",
+                    tool = "weather",
+                    content = "{\"temperature\":72}",
+                    metaInfo = RequestMetaInfo.Empty
+                )
+            ),
+            id = "p-tool-history"
+        )
+
+        client.execute(prompt, DeepSeekModels.DeepSeekReasoner)
+
+        assertNotNull(capturedBody, "Captured request body should not be null")
+        val messages = KotlinxJson.parseToJsonElement(capturedBody).jsonObject["messages"]!!.jsonArray
+
+        assertEquals(3, messages.size, "Reasoning and tool calls should be merged into a single assistant message")
+        val assistantMessage = messages[1].jsonObject
+        assertEquals("assistant", assistantMessage["role"]?.jsonPrimitive?.contentOrNull)
+        assertEquals(
+            "I should call the weather tool first.",
+            assistantMessage["reasoning_content"]?.jsonPrimitive?.contentOrNull
+        )
+        assertEquals(
+            "I should call the weather tool first.",
+            assistantMessage["content"]?.jsonPrimitive?.contentOrNull
+        )
+        val toolCalls = assistantMessage["tool_calls"]!!.jsonArray
+        assertEquals(1, toolCalls.size)
+        assertEquals(
+            "weather",
+            toolCalls[0].jsonObject["function"]!!.jsonObject["name"]!!.jsonPrimitive.contentOrNull
+        )
     }
 
     @Test

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-mistralai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/mistralai/MistralAILLMClientTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-mistralai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/mistralai/MistralAILLMClientTest.kt
@@ -151,6 +151,38 @@ class MistralAILLMClientTest {
         }
     """.trimIndent()
 
+    //language=json
+    val toolCallWithReasoningBody = """
+        {
+          "id": "chatcmpl-tool",
+          "object": "chat.completion",
+          "created": 1716920005,
+          "model": "mistral-medium-2508",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "content": "",
+                "reasoning_content": "I should call the weather tool first.",
+                "tool_calls": [
+                  {
+                    "id": "call_weather",
+                    "type": "function",
+                    "function": {
+                      "name": "weather",
+                      "arguments": "{\"city\":\"Boston\"}"
+                    }
+                  }
+                ]
+              },
+              "finish_reason": "tool_calls"
+            }
+          ],
+          "usage": {"total_tokens": 10, "prompt_tokens": 5, "completion_tokens": 5}
+        }
+    """.trimIndent()
+
     @Test
     fun testExecute() = runTest {
         var capturedUrl = ""
@@ -261,6 +293,33 @@ class MistralAILLMClientTest {
         // For now, we'd only verify that streaming flow can be created
         // as MockEngine does not support Ktor SSE end-to-end streaming reliably in tests
         assertNotNull(flow, "Flow should not be null")
+    }
+
+    @Test
+    fun testExecuteToolCallResponsePreservesReasoningMessage() = runTest {
+        val engine = MockEngine.Companion { _ ->
+            respond(
+                content = toolCallWithReasoningBody,
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+            )
+        }
+        val http = HttpClient(engine) {}
+        val client = MistralAILLMClient(apiKey = key, baseClient = http, clock = FixedClock)
+
+        val prompt = Prompt.build(id = "p-tool-response", clock = FixedClock) {
+            user("What is the weather in Boston?")
+        }
+
+        val responses = client.execute(prompt, MistralAIModels.Chat.MistralMedium31)
+
+        assertEquals(2, responses.size, "Response should contain reasoning and tool call")
+        assertIs<Message.Reasoning>(responses[0])
+        assertEquals("I should call the weather tool first.", responses[0].content)
+        val toolCall = assertIs<Message.Tool.Call>(responses[1])
+        assertEquals("call_weather", toolCall.id)
+        assertEquals("weather", toolCall.tool)
+        assertEquals("{\"city\":\"Boston\"}", toolCall.content)
     }
 
     @Test

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/base/AbstractOpenAILLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/base/AbstractOpenAILLMClient.kt
@@ -393,71 +393,89 @@ public abstract class AbstractOpenAILLMClient<TResponse : OpenAIBaseLLMResponse,
         )
     }
 
+    private fun OpenAIMessage.Assistant.reasoningMessageOrNull(metaInfo: ResponseMetaInfo): Message.Reasoning? =
+        if (reasoningContent != null) {
+            Message.Reasoning(
+                content = reasoningContent,
+                metaInfo = metaInfo
+            )
+        } else {
+            null
+        }
+
+    private fun OpenAIMessage.Assistant.toolCallMessages(metaInfo: ResponseMetaInfo): List<Message.Tool.Call> =
+        toolCalls?.map { toolCall ->
+            Message.Tool.Call(
+                id = toolCall.id,
+                tool = toolCall.function.name,
+                /*
+                 If the tool has no arguments, OpenRouter puts an empty string in the arguments instead of an empty object
+                 But we always expect arguments to be a JSON object. Fixing this.
+                 */
+                content = toolCall.function.arguments
+                    .takeIf { it.isNotEmpty() }
+                    ?: "{}",
+                metaInfo = metaInfo
+            )
+        } ?: emptyList()
+
+    private fun OpenAIMessage.Assistant.assistantMessageOrNull(
+        finishReason: String?,
+        metaInfo: ResponseMetaInfo
+    ): Message.Assistant? =
+        if (content != null && content.text().isNotEmpty()) {
+            Message.Assistant(
+                content = this.content.text(),
+                finishReason = finishReason,
+                metaInfo = metaInfo
+            )
+        } else {
+            null
+        }
+
+    private fun OpenAIMessage.Assistant.audioMessageOrNull(
+        metaInfo: ResponseMetaInfo,
+        finishReason: String? = null,
+    ): Message.Assistant? =
+        if (audio?.data != null) {
+            Message.Assistant(
+                parts = buildList {
+                    audio.transcript?.let { add(ContentPart.Text(it)) }
+                    add(
+                        ContentPart.Audio(
+                            content = AttachmentContent.Binary.Base64(audio.data),
+                            format = "unknown", // FIXME: clarify format from response
+                        )
+                    )
+                },
+                finishReason = finishReason,
+                metaInfo = metaInfo
+            )
+        } else {
+            null
+        }
+
     @OptIn(ExperimentalEncodingApi::class)
     protected fun OpenAIMessage.toMessageResponses(
         finishReason: String?,
         metaInfo: ResponseMetaInfo
     ): List<Message.Response> {
-        return when {
-            this is OpenAIMessage.Assistant && !this.toolCalls.isNullOrEmpty() -> {
-                this.toolCalls.map { toolCall ->
-                    Message.Tool.Call(
-                        id = toolCall.id,
-                        tool = toolCall.function.name,
-                        /*
-                         If the tool has no arguments, OpenRouter puts an empty string in the arguments instead of an empty object
-                         But we always expect arguments to be a JSON object. Fixing this.
-                         */
-                        content = toolCall.function.arguments
-                            .takeIf { it.isNotEmpty() }
-                            ?: "{}",
-                        metaInfo = metaInfo
-                    )
-                }
+        check(this is OpenAIMessage.Assistant) { "Expected OpenAIMessage.Assistant, got $this" }
+        val messageResponses = sequence {
+            yield(reasoningMessageOrNull(metaInfo))
+            yieldAll(toolCallMessages(metaInfo))
+            yield(assistantMessageOrNull(finishReason, metaInfo))
+            yield(audioMessageOrNull(metaInfo, finishReason))
+        }.filterNotNull().toList()
+        if (messageResponses.isEmpty()) {
+            if (finishReason != null) {
+                return listOf(Message.Assistant("", metaInfo, finishReason))
             }
-
-            this is OpenAIMessage.Assistant && this.reasoningContent != null && this.content != null -> listOf(
-                Message.Reasoning(
-                    content = this.reasoningContent,
-                    metaInfo = metaInfo
-                ),
-                Message.Assistant(
-                    content = this.content.text(),
-                    finishReason = finishReason,
-                    metaInfo = metaInfo
-                )
-            )
-
-            this.content != null -> listOf(
-                Message.Assistant(
-                    content = this.content!!.text(),
-                    finishReason = finishReason,
-                    metaInfo = metaInfo
-                )
-            )
-
-            this is OpenAIMessage.Assistant && this.audio?.data != null -> listOf(
-                Message.Assistant(
-                    parts = buildList {
-                        this@toMessageResponses.audio.transcript?.let { add(ContentPart.Text(it)) }
-                        add(
-                            ContentPart.Audio(
-                                content = AttachmentContent.Binary.Base64(this@toMessageResponses.audio.data),
-                                format = "unknown", // FIXME: clarify format from response
-                            )
-                        )
-                    },
-                    finishReason = finishReason,
-                    metaInfo = metaInfo
-                )
-            )
-
-            else -> {
-                val exception = LLMClientException(clientName, "Unexpected response: no tool calls and no content")
-                logger.error(exception) { exception.message }
-                throw exception
-            }
+            val exception = LLMClientException(clientName, "Unexpected response: no tool calls and no content")
+            logger.error(exception) { exception.message }
+            throw exception
         }
+        return messageResponses
     }
 
     protected fun LLModel.requireCapability(capability: LLMCapability, message: String? = null) {

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/build.gradle.kts
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/build.gradle.kts
@@ -27,6 +27,7 @@ kotlin {
 
         jvmTest {
             dependencies {
+                implementation(libs.ktor.client.mock)
                 implementation(libs.ktor.client.cio)
             }
         }

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openai/OpenAIChatCompletionLLMClientTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openai/OpenAIChatCompletionLLMClientTest.kt
@@ -1,0 +1,85 @@
+package ai.koog.prompt.executor.clients.openai
+
+import ai.koog.prompt.dsl.Prompt
+import ai.koog.prompt.message.Message
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.time.Clock
+import kotlin.time.Instant
+
+class OpenAIChatCompletionLLMClientTest {
+
+    object FixedClock : Clock {
+        override fun now(): Instant = Instant.fromEpochMilliseconds(0)
+    }
+
+    private val key = "test-key"
+
+    //language=json
+    private val toolCallWithReasoningBody = """
+        {
+          "id": "chatcmpl-tool",
+          "object": "chat.completion",
+          "created": 1716920005,
+          "model": "gpt-4o",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "content": "",
+                "reasoning_content": "I should call the weather tool first.",
+                "tool_calls": [
+                  {
+                    "id": "call_weather",
+                    "type": "function",
+                    "function": {
+                      "name": "weather",
+                      "arguments": "{\"city\":\"Boston\"}"
+                    }
+                  }
+                ]
+              },
+              "finish_reason": "tool_calls"
+            }
+          ],
+          "usage": {"total_tokens": 10, "prompt_tokens": 5, "completion_tokens": 5}
+        }
+    """.trimIndent()
+
+    @Test
+    fun testExecuteToolCallResponsePreservesReasoningMessage() = runTest {
+        val engine = MockEngine.Companion { _ ->
+            respond(
+                content = toolCallWithReasoningBody,
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+            )
+        }
+        val http = HttpClient(engine) {}
+        val client = OpenAILLMClient(apiKey = key, baseClient = http, clock = FixedClock)
+
+        val prompt = Prompt.build(id = "p-tool-response", clock = FixedClock, params = OpenAIChatParams()) {
+            user("What is the weather in Boston?")
+        }
+
+        val responses = client.execute(prompt, OpenAIModels.Chat.GPT4o)
+
+        assertEquals(2, responses.size, "Response should contain reasoning and tool call")
+        assertIs<Message.Reasoning>(responses[0])
+        assertEquals("I should call the weather tool first.", responses[0].content)
+        val toolCall = assertIs<Message.Tool.Call>(responses[1])
+        assertEquals("call_weather", toolCall.id)
+        assertEquals("weather", toolCall.tool)
+        assertEquals("{\"city\":\"Boston\"}", toolCall.content)
+    }
+}

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openrouter-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openrouter/OpenRouterLLMClientTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openrouter-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openrouter/OpenRouterLLMClientTest.kt
@@ -1,0 +1,85 @@
+package ai.koog.prompt.executor.clients.openrouter
+
+import ai.koog.prompt.dsl.Prompt
+import ai.koog.prompt.message.Message
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.time.Clock
+import kotlin.time.Instant
+
+class OpenRouterLLMClientTest {
+
+    object FixedClock : Clock {
+        override fun now(): Instant = Instant.fromEpochMilliseconds(0)
+    }
+
+    private val apiKey = "test-api-key"
+
+    //language=json
+    private val toolCallWithReasoningBody = """
+        {
+          "id": "chatcmpl-tool",
+          "created": 1716920005,
+          "model": "openai/gpt-4o-mini",
+          "object": "chat.completion",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "content": "",
+                "reasoning_content": "I should call the weather tool first.",
+                "tool_calls": [
+                  {
+                    "id": "call_weather",
+                    "type": "function",
+                    "function": {
+                      "name": "weather",
+                      "arguments": "{\"city\":\"Boston\"}"
+                    }
+                  }
+                ]
+              },
+              "finish_reason": "tool_calls"
+            }
+          ],
+          "usage": {"total_tokens": 10, "prompt_tokens": 5, "completion_tokens": 5}
+        }
+    """.trimIndent()
+
+    @Test
+    fun testExecuteToolCallResponsePreservesReasoningMessage() = runTest {
+        val engine = MockEngine.Companion { _ ->
+            respond(
+                content = toolCallWithReasoningBody,
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+            )
+        }
+        val http = HttpClient(engine) {}
+        val client = OpenRouterLLMClient(apiKey = apiKey, baseClient = http, clock = FixedClock)
+
+        val prompt = Prompt.build(id = "p-tool-response", clock = FixedClock) {
+            user("What is the weather in Boston?")
+        }
+
+        val responses = client.execute(prompt, OpenRouterModels.GPT4oMini)
+
+        assertEquals(2, responses.size, "Response should contain reasoning and tool call")
+        assertIs<Message.Reasoning>(responses[0])
+        assertEquals("I should call the weather tool first.", responses[0].content)
+        val toolCall = assertIs<Message.Tool.Call>(responses[1])
+        assertEquals("call_weather", toolCall.id)
+        assertEquals("weather", toolCall.tool)
+        assertEquals("{\"city\":\"Boston\"}", toolCall.content)
+    }
+}


### PR DESCRIPTION
This PR keeps `reasoningContent` in tool calls and merge them with tool calls to satisfy DeepSeek API requirements.

closes #21